### PR TITLE
Support adaptive background thresholding for Xenium data via stain_bg_percentile argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Use `help(scs.segment_cells)` in python to see more instructions on the usages.
 #### Background threshold
 By default, SCS identifies background spots using an absolute stain intensity cutoff of `stain_bg_threshold=10`, which works well for low-range fluorescence images (e.g. Stereo-seq, Seq-Scope).
 
-For **Visium** or other platforms that use **H&E staining** (pixel values 0–255), nearly every pixel exceeds 10, so no background samples are collected and the model cannot train properly. In this case, pass `stain_bg_percentile` to compute the threshold adaptively from the data at runtime:
+For **Visium**, **Xenium** or other platforms that use **H&E staining** (pixel values 0-255), nearly every pixel exceeds 10, so no background samples are collected and the model cannot train properly. In this case, pass `stain_bg_percentile` to compute the threshold adaptively from the data at runtime:
 ```python
 scs.segment_cells(bin_file, image_file, stain_bg_percentile=10)  # 10th percentile of the stain layer
 ```

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ scs.segment_cells(bin_file, image_file, align='rigid')
 ```
 Use `help(scs.segment_cells)` in python to see more instructions on the usages.
 
+#### Background threshold
+By default, SCS identifies background spots using an absolute stain intensity cutoff of `stain_bg_threshold=10`, which works well for low-range fluorescence images (e.g. Stereo-seq, Seq-Scope).
+
+For **Visium** or other platforms that use **H&E staining** (pixel values 0–255), nearly every pixel exceeds 10, so no background samples are collected and the model cannot train properly. In this case, pass `stain_bg_percentile` to compute the threshold adaptively from the data at runtime:
+```python
+scs.segment_cells(bin_file, image_file, stain_bg_percentile=10)  # 10th percentile of the stain layer
+```
+The `stain_bg_percentile` parameter overrides `stain_bg_threshold` when set.
+
 The `segment_cells` function will run three steps to segment the provided patch: (*i*) preprocessing, *i.e.*, identifying nuclei and preparing data for the transformer, (*ii*) training the transformer and inference on all the spots in the patch, (*iii*), postprocessing, *i.e.*, gradient flow tracking. The preprocessing time on the demo patch will be about 10 minutes, transformer training will take roughly 1 hour with an Nvidia GeForce 10 series graphics card, and the postprocessing will take about 5 minutes.
 
 ### Processing large-scale data

--- a/src/preprocessing.py
+++ b/src/preprocessing.py
@@ -10,7 +10,7 @@ import os
 from scipy.sparse import lil_matrix, csr_matrix, vstack
 
 
-def preprocess(bin_file, image_file, prealigned, align, startx, starty, patchsize, bin_size, n_neighbor):
+def preprocess(bin_file, image_file, prealigned, align, startx, starty, patchsize, bin_size, n_neighbor, stain_bg_threshold=10, stain_bg_percentile=None):
     #read data
     if prealigned:
         adatasub = st.io.read_bgi_agg(bin_file, image_file, prealigned=True)
@@ -27,6 +27,12 @@ def preprocess(bin_file, image_file, prealigned, align, startx, starty, patchsiz
     adatasub.layers['unspliced'] = adatasub.X
     patchsizex = adatasub.X.shape[0]
     patchsizey = adatasub.X.shape[1]
+
+    if stain_bg_percentile is not None:
+        stain_bg_threshold = float(np.percentile(np.asarray(adatasub.layers['stain']), stain_bg_percentile))
+        print(f'stain_bg_threshold ({stain_bg_percentile}th percentile):', stain_bg_threshold)
+    else:
+        print('stain_bg_threshold:', stain_bg_threshold)
 
     #align staining image with bins
     before = adatasub.layers['stain'].copy()
@@ -230,7 +236,7 @@ def preprocess(bin_file, image_file, prealigned, align, startx, starty, patchsiz
                 if idx >= 0 and idx < all_exp_merged_bins.shape[0] and np.sum(all_exp_merged_bins[idx, :]) > 0:
                     backgroud = True
                     for nucleus in watershed2center:
-                        if (i - watershed2center[nucleus][0]) ** 2 + (j - watershed2center[nucleus][1]) ** 2 <= 900 or adatasub.layers['stain'][i, j] > 10:
+                        if (i - watershed2center[nucleus][0]) ** 2 + (j - watershed2center[nucleus][1]) ** 2 <= 900 or adatasub.layers['stain'][i, j] > stain_bg_threshold:
                             backgroud = False
                             break
                     if backgroud:

--- a/src/scs.py
+++ b/src/scs.py
@@ -2,7 +2,7 @@ import math
 import numpy as np
 from src import preprocessing, transformer, postprocessing
 
-def segment_cells(bin_file, image_file, prealigned=False, align=None, patch_size=0, bin_size=3, n_neighbor=50, epochs=100, r_estimate=15, val_ratio=0.0625):
+def segment_cells(bin_file, image_file, prealigned=False, align=None, patch_size=0, bin_size=3, n_neighbor=50, epochs=100, r_estimate=15, val_ratio=0.0625, stain_bg_threshold=10, stain_bg_percentile=None):
     """
     Parameters:
         bin_file - string, tsv file for detected RNAs
@@ -15,9 +15,11 @@ def segment_cells(bin_file, image_file, prealigned=False, align=None, patch_size
         epochs - int, the training epochs of the transformer model, default 100
         r_estimate - int, the estimated radius (spots) of cells, used to calculate the priors for transformer predictions, default 15
         val_ratio - float, the fraction of the patch set aside for validation, default 0.0625 (1/4 height x 1/4 width)
+        stain_bg_threshold - float, absolute stain intensity threshold; a spot is background only if its stain value is at or below this value, default 10
+        stain_bg_percentile - float or None, if set (e.g. 10.0), overrides stain_bg_threshold with the given percentile of the stain layer computed at runtime; useful for Visium H&E data where pixel values are in the 0-255 range, default None
     """
     if patch_size == 0:
-        preprocessing.preprocess(bin_file, image_file, prealigned, align, 0, 0, patch_size, bin_size, n_neighbor)
+        preprocessing.preprocess(bin_file, image_file, prealigned, align, 0, 0, patch_size, bin_size, n_neighbor, stain_bg_threshold, stain_bg_percentile)
         transformer.train(0, 0, patch_size, epochs, val_ratio)
         postprocessing.postprocess(0, 0, patch_size, bin_size, r_estimate)
     else:
@@ -37,7 +39,7 @@ def segment_cells(bin_file, image_file, prealigned=False, align=None, patch_size
             for startc in range(0, cmax, patch_size):
                 try:
                     print('Processing the patch ' + str(startr) + ':' + str(startc) + '...')
-                    preprocessing.preprocess(bin_file, image_file, prealigned, align, startr, startc, patch_size, bin_size, n_neighbor)
+                    preprocessing.preprocess(bin_file, image_file, prealigned, align, startr, startc, patch_size, bin_size, n_neighbor, stain_bg_threshold, stain_bg_percentile)
                     transformer.train(startr, startc, patch_size, epochs, val_ratio)
                     postprocessing.postprocess(startr, startc, patch_size, bin_size, r_estimate)
                 except Exception as e:


### PR DESCRIPTION
Hi hi,

I wanted to share my experience running SCS on 10x Xenium data - I'm trying to add it to the [nf-core](https://github.com/nf-core) [spatialxe](https://github.com/nf-core/spatialxe) pipeline ( https://github.com/nf-core/spatialxe/pull/130 ). I found that the default background threshold (stain_bg_threshold=10) does not work well for Xenium data, since almost all pixels have values above 10. This results in no background being detected and the model failing to train properly. That's a pull request related to the issue I just opened https://github.com/chenhcs/SCS/issues/21 . Please find in the attachment my test code [Test_SCS2Visium.ipynb](https://github.com/user-attachments/files/27047253/Test_SCS2Visium.ipynb) using the breast cancer tumor Xenium data (https://www.10xgenomics.com/products/xenium-in-situ/preview-dataset-human-breast), and the screenshot of the results:
 
<img width="1228" height="421" alt="Results_SCS_Xenium" src="https://github.com/user-attachments/assets/0f195806-e99e-4f34-9d7d-a16ee17218b0" />



I hope it's fine that I prepared a pull request to adjust for that. Summary of changes:

    - Added an argument to the preprocess funcion called stain_bg_percentile that allows users to specify a percentile-based adaptive background threshold for stain intensity.
    - Added a note in the README and example scripts about using stain_bg_percentile for Visium/H&E data.
    - Clarified that the default threshold is for low-range fluorescence images, and percentile-based thresholding is recommended for H&E.

Let me know if you'd like any further changes. Thanks for maintaining SCS!

Cheers,
Kasia